### PR TITLE
fix: correct friend name column order

### DIFF
--- a/nonebot_plugin_splatoon3_nso/handle/my.py
+++ b/nonebot_plugin_splatoon3_nso/handle/my.py
@@ -375,7 +375,7 @@ async def get_friends_md(splatoon, lang='zh-CN'):
         img = f'''<img height="40" src="{icon_img}"/>'''
         if f['playerName'] and f['playerName'] != f['nickname']:
             nickname = game_name_replace(f['nickname'])
-            n = f'{f["playerName"]}|{img}|{nickname}'
+            n = f'{nickname}|{img}|{n}'
         else:
             n = f'{n}|{img}|'
         msg += f'''|{n}| {_state}|\n'''


### PR DESCRIPTION
`/friends` 命令中，NS 好友与 SP3 好友名称的生成和映射逻辑有问题。实际生成的图片名称是反过来的。
<img width="1550" height="1660" alt="image" src="https://github.com/user-attachments/assets/e3e0aad1-6bd0-49b0-8315-a1434135354b" />
commit中已修复此问题。