### PR TITLE
feat: 适配discord协议

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ _✨ splatoon3 nso查询插件 ✨_
 <a href="https://github.com/nonebot/adapter-qq">
 <img src="https://img.shields.io/badge/QQ-Adapter-lightgrey?style=social" alt="QQ">
 </a>
+<a href="https://github.com/nonebot/adapter-discord">
+<img src="https://img.shields.io/badge/discord-Adapter-lightgrey?style=social&logo=discord" alt="discord">
+</a>
 </p>
 
 </div>
@@ -46,7 +49,7 @@ _✨ splatoon3 nso查询插件 ✨_
 - 一个基于nonebot2框架的splatoon3
   nso查询插件,支持onebot11,onebot12,[telegram](https://github.com/nonebot/adapter-telegram)
   协议,[kook](https://github.com/Tian-que/nonebot-adapter-kaiheila)
-  协议,[QQ官方bot](https://github.com/nonebot/adapter-qq)协议
+  协议,[QQ官方bot](https://github.com/nonebot/adapter-qq)协议,[discord](https://github.com/nonebot/adapter-discord)协议
 - 本仓库代码是基于paul的[splatoon3-bot](https://github.com/paul-sama/splatoon3-bot)内的nso插件进行的重构版本
 - 建议配合我做的[日程查询插件](https://github.com/Cypas/splatoon3-schedule)一起使用
 

--- a/nonebot_plugin_splatoon3_nso/__init__.py
+++ b/nonebot_plugin_splatoon3_nso/__init__.py
@@ -21,7 +21,7 @@ __plugin_meta__ = PluginMetadata(
     homepage="https://github.com/Cypas/splatoon3-nso",
     # 发布必填。
     config=Config,
-    supported_adapters={"~onebot.v11", "~onebot.v12", "~telegram", "~kaiheila", "~qq"},
+    supported_adapters={"~onebot.v11", "~onebot.v12", "~telegram", "~kaiheila", "~qq", "~discord"},
 )
 
 

--- a/nonebot_plugin_splatoon3_nso/handle/send_msg.py
+++ b/nonebot_plugin_splatoon3_nso/handle/send_msg.py
@@ -121,6 +121,13 @@ async def notify_to_private(platform: str, user_id: str, msg: str):
         if kook_bot:
             bot = kook_bot
 
+    # discord平台
+    elif platform == "Discord":
+        for k, b in bots.items():
+            if isinstance(b, Dc_Bot):
+                bot = b
+                break
+
     if bot:
         # 发送私信
         await send_private_msg(bot, user_id, msg)
@@ -323,6 +330,8 @@ async def send_msg(bot: Bot, event: Event, msg: str | bytes, file_name="", skip_
                                    message="群内未允许小鱿鱿主动发送消息，请发送 /免艾特申请 并根据帮助提示启用小鱿鱿主动消息权限")
                 else:
                     logger.warning(f"QQ send msg error: {e}")
+        elif isinstance(bot, Dc_Bot):
+            await bot.send(event, message=Dc_MsgSeg.text(msg), reply_message=reply_mode)
 
     elif isinstance(msg, bytes):
         # 图片
@@ -382,6 +391,10 @@ async def send_msg(bot: Bot, event: Event, msg: str | bytes, file_name="", skip_
                                    message="群内未允许小鱿鱿主动发送消息，请发送 /免艾特申请 并根据帮助提示启用小鱿鱿主动消息权限")
                 else:
                     logger.warning(f"QQ send msg error: {e}")
+        elif isinstance(bot, Dc_Bot):
+            up_file_name = file_name if file_name else "temp.png"
+            await bot.send(event, message=Dc_MsgSeg.attachment(file=up_file_name, content=img),
+                           reply_message=reply_mode)
 
     if not skip_ad and trigger_with_probability():
         if isinstance(bot, QQ_Bot):
@@ -404,6 +417,8 @@ async def send_channel_msg(bot: Bot, source_id, msg: str | bytes):
                 logger.warning(f"主动消息发送失败，api操作结果为{e.__dict__}")
         elif isinstance(bot, Tg_Bot):
             await bot.send_message(chat_id=source_id, text=msg)
+        elif isinstance(bot, Dc_Bot):
+            await bot.send_to(channel_id=source_id, message=Dc_MsgSeg.text(msg))
     elif isinstance(msg, bytes):
         # 图片
         img = msg
@@ -419,6 +434,9 @@ async def send_channel_msg(bot: Bot, source_id, msg: str | bytes):
                 logger.warning(f"主动消息发送失败，api操作结果为{e.__dict__}")
         elif isinstance(bot, Tg_Bot):
             await bot.send_photo(source_id, img)
+        elif isinstance(bot, Dc_Bot):
+            await bot.send_to(channel_id=source_id,
+                              message=Dc_MsgSeg.attachment(file="temp.png", content=img))
 
 
 async def send_private_msg(bot: Bot, source_id, msg: str | bytes, event=None):
@@ -437,6 +455,9 @@ async def send_private_msg(bot: Bot, source_id, msg: str | bytes, event=None):
                 logger.warning(f"主动消息发送失败，api操作结果为{e.__dict__}")
         elif isinstance(bot, Tg_Bot):
             await bot.send_message(chat_id=source_id, text=msg)
+        elif isinstance(bot, Dc_Bot):
+            channel = await bot.create_DM(recipient_id=source_id)
+            await bot.send_to(channel_id=channel.id, message=Dc_MsgSeg.text(msg))
 
     elif isinstance(msg, bytes):
         # 图片
@@ -453,6 +474,10 @@ async def send_private_msg(bot: Bot, source_id, msg: str | bytes, event=None):
                 logger.warning(f"主动消息发送失败，api操作结果为{e.__dict__}")
         elif isinstance(bot, Tg_Bot):
             await bot.send_photo(source_id, img)
+        elif isinstance(bot, Dc_Bot):
+            channel = await bot.create_DM(recipient_id=source_id)
+            await bot.send_to(channel_id=channel.id,
+                              message=Dc_MsgSeg.attachment(file="temp.png", content=img))
 
 
 async def _qq_bot_send_md(bot: QQ_Bot, event: Event, qq_md):

--- a/nonebot_plugin_splatoon3_nso/handle/utils.py
+++ b/nonebot_plugin_splatoon3_nso/handle/utils.py
@@ -386,6 +386,10 @@ async def get_event_info(bot, event):
         data.update({
             'user_name': user_name,
         })
+    elif isinstance(bot, Dc_Bot):
+        data.update({
+            'user_name': _event.get('author', {}).get('username') or '',
+        })
 
     return data
 

--- a/nonebot_plugin_splatoon3_nso/utils/bot.py
+++ b/nonebot_plugin_splatoon3_nso/utils/bot.py
@@ -61,12 +61,20 @@ from nonebot.adapters.qq.models import (
 from nonebot.adapters.qq import GroupAddRobotEvent as QQ_GAddEvent
 from nonebot.adapters.qq import FriendAddEvent as QQ_FAddEvent
 
+# discord协议
+from nonebot.adapters.discord import Bot as Dc_Bot
+from nonebot.adapters.discord import Message as Dc_Msg
+from nonebot.adapters.discord import MessageSegment as Dc_MsgSeg
+from nonebot.adapters.discord import MessageEvent as Dc_ME
+from nonebot.adapters.discord import DirectMessageCreateEvent as Dc_PME  # 私信
+from nonebot.adapters.discord import GuildMessageCreateEvent as Dc_GME  # 服务器频道消息
+
 # bot
-All_BOT = (V11_Bot, V12_Bot, Kook_Bot, Tg_Bot, QQ_Bot)
+All_BOT = (V11_Bot, V12_Bot, Kook_Bot, Tg_Bot, QQ_Bot, Dc_Bot)
 # 需要限制qq平台停用的功能也应该是在该功能前直接阻断，而不是后续再进行过滤，故弃用All_BOT_Without_QQ
 
 # 公开发言消息类型
-All_Group_Message = (Kook_CME, Tg_GME, Tg_CME, QQ_CME, QQ_GATME, QQ_GME, V11_GME, V12_GME, V12_CME)
+All_Group_Message = (Kook_CME, Tg_GME, Tg_CME, QQ_CME, QQ_GATME, QQ_GME, V11_GME, V12_GME, V12_CME, Dc_GME)
 All_Group_Message_Without_QQ_G = (Kook_CME, Tg_GME, Tg_CME, QQ_CME, V11_GME, V12_GME, V12_CME)
 # 私聊消息
-All_Private_Message = (Kook_PME, Tg_PME, QQ_PME, QQ_C2CME, V11_PME, V12_PME)
+All_Private_Message = (Kook_PME, Tg_PME, QQ_PME, QQ_C2CME, V11_PME, V12_PME, Dc_PME)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "nonebot-adapter-telegram>=0.1.0b20,<0.2",
     "nonebot-adapter-kaiheila>=0.3.4,<0.4",
     "nonebot-adapter-qq>=1.7.1,<2",
+    "nonebot-adapter-discord>=1.1.9,<2",
     "nonebot-plugin-apscheduler>=0.5.0,<0.6",
     "nonebot_plugin_datastore>=1.3.0,<2",
     "nonebot_plugin_htmlrender>=0.6.7,<0.7",


### PR DESCRIPTION
配合 splatoon3-schedule 的 discord 适配（https://github.com/Cypas/splatoon3-schedule/pull/55），nso 插件这边的部分，其他平台逻辑没有改动。

- utils/bot.py 引入 discord 别名，并加进 All_BOT / All_Group_Message / All_Private_Message，现有 matcher 和 checker 就能覆盖 discord
- send_msg.py 的发送函数加 discord 分支（图片直接发字节，主动私信先 create_DM 再发），notify_to_private 加 discord 分支，从在线 bots 里找 discord bot，不需要新配置项
- get_event_info 补了 discord 的 user_name 解析
- supported_adapters 加 ~discord，pyproject 加 nonebot-adapter-discord>=1.1.9,<2

测试情况：discord bot 已实机常驻运行，插件加载和事件接入正常。未登录提示、/login 私信引导、频道内 /login 的“需要私信”保护、/last 参数解析这些路径用构造事件+拦截 api 调用的方式回归验证过。真实 NSO 账号绑定的完整流程还在测，有问题我会在这里补充。

另外 discord 用户习惯 slash 指令，我写了个独立的桥接小插件（注册 slash 指令并转发成等价文字消息事件，本插件不用改动），没放进这个 PR，有需要的话可以再提。
