### PR TITLE
fix: 修复discord群消息类型遗漏与nso版本号回退失效

### DIFF
--- a/nonebot_plugin_splatoon3_nso/s3s/iksm.py
+++ b/nonebot_plugin_splatoon3_nso/s3s/iksm.py
@@ -423,7 +423,8 @@ class S3S:
                 except:  # error with web request
                     pass
 
-                return NSOAPP_VER_FALLBACK
+                NSOAPP_VERSION = NSOAPP_VER_FALLBACK
+                return NSOAPP_VERSION
 
     @staticmethod
     async def get_web_view_ver(bhead=None, gtoken=""):

--- a/nonebot_plugin_splatoon3_nso/utils/bot.py
+++ b/nonebot_plugin_splatoon3_nso/utils/bot.py
@@ -75,6 +75,6 @@ All_BOT = (V11_Bot, V12_Bot, Kook_Bot, Tg_Bot, QQ_Bot, Dc_Bot)
 
 # 公开发言消息类型
 All_Group_Message = (Kook_CME, Tg_GME, Tg_CME, QQ_CME, QQ_GATME, QQ_GME, V11_GME, V12_GME, V12_CME, Dc_GME)
-All_Group_Message_Without_QQ_G = (Kook_CME, Tg_GME, Tg_CME, QQ_CME, V11_GME, V12_GME, V12_CME)
+All_Group_Message_Without_QQ_G = (Kook_CME, Tg_GME, Tg_CME, QQ_CME, V11_GME, V12_GME, V12_CME, Dc_GME)
 # 私聊消息
 All_Private_Message = (Kook_PME, Tg_PME, QQ_PME, QQ_C2CME, V11_PME, V12_PME, Dc_PME)


### PR DESCRIPTION
两处独立的小修复。

**All_Group_Message_Without_QQ_G 缺少 Dc_GME**

该元组未加入 discord 群消息类型，以此元组做 rule 的功能在 discord 频道不会触发。schedule 仓库已在 857bfb5 修正同一问题，nso 这侧遗漏。

**get_nsoapp_version 回退分支未写入全局变量**

nxapi config 与 App Store 两路都失败时，该函数返回 `NSOAPP_VER_FALLBACK` 但没有给全局 `NSOAPP_VERSION` 赋值，全局量保持 `"unknown"`。而 `call_f_api` 直接读取全局量，于是 `X-znca-Version` 发出 `unknown`，被 f 接口拒绝：

```
f resp status_code:400,error:{"error":"invalid_request","error_description":"Invalid X-znca-Version value"}
```

近期 nxapi 的 `/config` 端点不稳定，会稳定触发这条路径。
